### PR TITLE
added backup depends-sources

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -6,6 +6,7 @@ SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
 NO_WALLET ?=
 NO_UPNP ?=
+FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
 
 BUILD = $(shell ./config.guess)
 HOST ?= $(BUILD)


### PR DESCRIPTION

<img width="760" alt="qtbase-fail-download" src="https://user-images.githubusercontent.com/92787297/188315482-71682a42-70f4-487c-8dee-be8315967717.png">
for backup (website https://download.qt.io) if source master download fail